### PR TITLE
Remove whoissound from Assignees

### DIFF
--- a/.github/ISSUE_TEMPLATE/bot-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bot-bug-report.md
@@ -3,7 +3,7 @@ name: Bot Bug Report
 about: Report a bug related to the bot
 title: ''
 labels: ''
-assignees: 'whoissound, Flqsh, LostBreezely'
+assignees: 'Flqsh, LostBreezely'
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/website-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/website-bug-report.md
@@ -3,7 +3,7 @@ name: Website Bug Report
 about: Report a bug related to the website
 title: ''
 labels: ''
-assignees: 'whoissound, Flqsh, LostBreezely'
+assignees: 'Flqsh, LostBreezely'
 
 ---
 


### PR DESCRIPTION
# Proposed Changes

This change removes whoissound from the list of assignees as they are no longer part of the team.